### PR TITLE
feat: Add CI Workflow for lint, test, and release

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,6 +32,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    if: github.base_ref == 'master' || github.ref == 'refs/heads/master' # run on commits and PRs to master branch
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
@@ -57,7 +58,7 @@ jobs:
   semantic-release:
     runs-on: ubuntu-latest
     environment: personal
-    if: github.base_ref == 'refs/heads/master' || github.ref == 'refs/heads/master' # run on commits and PRs to master branch
+    if: github.base_ref == 'master' || github.ref == 'refs/heads/master' # run on commits and PRs to master branch
     needs: 
       - lint
       - test

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,40 +1,96 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: Python Workflow
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: 
+  - push
+  - pull_request
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
+    steps: 
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.ci.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.ci.txt ]; then pip install -r requirements.ci.txt; fi
+    - name: Lint with black
+      run: |
+        black --check .
 
+  test:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements.ci.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest black
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements.ci.txt ]; then pip install -r requirements.ci.txt; fi
         pip install .
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Lint with black
-      run: |
-        black --check .
     - name: Test with pytest
       run: |
         pytest
+
+  semantic-release:
+    runs-on: ubuntu-latest
+    environment: personal
+    if: github.base_ref == 'refs/heads/master' || github.ref == 'refs/heads/master' # run on commits and PRs to master branch
+    needs: 
+      - lint
+      - test
+    env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_REPOSITORY_URL: ${{ secrets.TWINE_REPOSITORY_URL }}
+    steps: 
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.ci.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.ci.txt ]; then pip install -r requirements.ci.txt; fi
+      - name: Semantic Release 
+        if: github.ref == 'refs/heads/master'  # if this is the master branch, assume triggered by push
+        id: semantic-release
+        uses: cycjimmy/semantic-release-action@v2 
+        with:
+          semantic_version: 16
+          extra_plugins: |
+            @semantic-release/exec
+      - name: Semantic non-Release
+        if: github.ref != 'refs/heads/master' # if this isn't the master branch, assume triggered by PR
+        run: |
+          scripts/publish.sh

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ venv/
 __pycache__/
 *.egg-info/
 dist
+.vscode/
+build/

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,11 @@
+{
+    "plugins": [
+        "@semantic-release/commit-analyzer", 
+        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/exec", {
+                "publishCmd": "scripts/publish.sh"
+            }
+        ]
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # ANBL-SCRAPER #
+-----------------
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/travipross/anbl-scraper/Python%20Workflow) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/travipross/anbl-scraper)
+
 Tools to crawl ANBL website to build a registry of individual product URLs, and to scrape metadata from each URL, extracting up-to-date information including pricing, volume, and quantity-per-container. 
 
 ## Installation

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,0 +1,4 @@
+black==20.8b1
+pytest==6.2.2
+wheel==0.36.2
+twine==3.3.0

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+python setup.py sdist bdist_wheel
+twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,9 @@ setup(
     name="anbl_scraper",
     version="0.0.1",
     packages=find_packages(),
+    use_scm_version=True,
     python_requires=">=3.2",
+    setup_requires=["setuptools_scm"],
     install_requires=[
         "beautifulsoup4",
         "requests",


### PR DESCRIPTION
This PR adds support for a comprehensive GitHub Actions lint, test, and release workflow.

* linting is provided by `black`
* testing is provided by `pytest`
* release is provided by `semantic-release` (only on PRs or commits to the `master` branch)

The `semantic-release` package is configured to generate an automatically versioned GitHub release, along with auto-generated release notes which are obtained by analyzing commit messages. 

**In order for `semantic-release` to version releases properly, commits to be considered must be prefixed with `fix:`, `feat:`, etc.**. See [here](https://github.com/semantic-release/semantic-release#commit-message-format) for more details about the required commit format.  

The `anbl_scraper` package has been set up to use [setuptools-scm](https://pypi.org/project/setuptools-scm/), which ensures the package is automatically built with the appropriate version number according to version-numbered commit tags (which are compatible with those automatically generated by `semantic-release`).

Wheel and source distributions are configured to be uploaded to a pre-configured repository using `twine` upon release.